### PR TITLE
Change recommends to suggests in metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -19,4 +19,4 @@ end
 
 depends 'yum', '~> 3.0'
 
-recommends 'exhibitor', '0.4.0'
+suggests 'exhibitor', '0.4.0'


### PR DESCRIPTION
This allows installation of cookbook with Berkshelf without uploading the exhibitor cookbook (hence avoiding dependency hell).

See https://github.com/berkshelf/berkshelf/issues/895
